### PR TITLE
Introduced dynamic `BAKERY*` variables

### DIFF
--- a/bakery/service/config.go
+++ b/bakery/service/config.go
@@ -6,8 +6,26 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"time"
+
+	"bytes"
+	"text/template"
+
 	"github.com/Masterminds/semver"
 	"github.com/smartrecruiters/docker-bakery/bakery/commons"
+)
+
+const (
+	builderNamePropName    = "BAKERY_BUILDER_NAME"
+	builderEmailPropName   = "BAKERY_BUILDER_EMAIL"
+	builderHostPropName    = "BAKERY_BUILDER_HOST"
+	buildDatePropName      = "BAKERY_BUILD_DATE"
+	imageHierarchyPropName = "BAKERY_IMAGE_HIERARCHY"
+	signatureValuePropName = "BAKERY_SIGNATURE_VALUE"
+	signatureEnvsPropName  = "BAKERY_SIGNATURE_ENVS"
+	imageVersionPropName   = "IMAGE_VERSION"
+	imageNamePropName      = "IMAGE_NAME"
+	dockerfileDirPropName  = "DOCKERFILE_DIR"
 )
 
 // ReadConfig reads configuration file from provided path and returns it as an object.
@@ -26,17 +44,24 @@ func ReadConfig(configFile string) (*Config, error) {
 }
 
 // UpdateDynamicProperties updates config object state with the corresponding values of all dynamic properties.
-func (cfg *Config) UpdateDynamicProperties(imgName, nextVersion, dockerfileDir string) {
-	cfg.Properties["IMAGE_NAME"] = imgName
-	cfg.Properties["IMAGE_VERSION"] = nextVersion
-	cfg.Properties["DOCKERFILE_DIR"] = dockerfileDir
-	cfg.setImageVersionProperty(imgName, nextVersion)
+// Called in every cycle of executing docker command.
+func (cfg *Config) UpdateDynamicProperties(dockerImg *DockerImage) {
+	nextVersion := dockerImg.GetNextVersionString()
+	buildDate := time.Now().Format("2006-01-02 15:04:05")
+	cfg.setBuildDate(buildDate)
+	cfg.setImageName(dockerImg.Name)
+	cfg.setDockerfileDir(dockerImg.DockerfileDir)
+	cfg.setConstantImageVersion(nextVersion)
+	cfg.setDynamicImageVersionProperty(dockerImg.Name, nextVersion)
+	cfg.setImageHierarchy(dockerImg)
+	cfg.buildSignature()
 }
 
 // UpdateVersionProperties updates config with versions of the images.
+// Called once after latest versions of images are known (after analysing entire structure)
 func (cfg *Config) UpdateVersionProperties(versions map[string]*semver.Version) {
 	for image, version := range versions {
-		cfg.setImageVersionProperty(image, version.String())
+		cfg.setDynamicImageVersionProperty(image, version.String())
 	}
 }
 
@@ -45,13 +70,106 @@ func (cfg *Config) UpdateVersionProperties(versions map[string]*semver.Version) 
 // - it is in uppercase
 // - has `-` and `.` replaced with `_`
 // - has the `_VERSION` suffix
-func (cfg *Config) setImageVersionProperty(imgName, version string) {
+// The result of invocation setDynamicImageVersionProperty('redis', '1.0.0')
+// would be property REDIS_VERSION = '1.0.0'
+func (cfg *Config) setDynamicImageVersionProperty(imgName, version string) {
 	imgNameInTmpl := strings.ToUpper(imgName)
 	imgNameInTmpl = strings.Replace(imgNameInTmpl, "-", "_", -1)
 	imgNameInTmpl = strings.Replace(imgNameInTmpl, ".", "_", -1)
 	propertyName := fmt.Sprintf("%s_VERSION", imgNameInTmpl)
 	commons.Debugf("Setting property %s to %s", propertyName, version)
 	cfg.Properties[propertyName] = version
+}
+
+// setImageVersion sets the IMAGE_VERSION property to the provided version.
+// In contrast to setDynamicImageVersionProperty it always works on the same IMAGE_VERSION property
+// that is needed in templating docker build/push command
+func (cfg *Config) setConstantImageVersion(version string) {
+	cfg.Properties[imageVersionPropName] = version
+}
+
+func (cfg *Config) setImageName(name string) {
+	cfg.Properties[imageNamePropName] = name
+}
+
+func (cfg *Config) setDockerfileDir(dir string) {
+	cfg.Properties[dockerfileDirPropName] = dir
+}
+
+func (cfg *Config) setBuildDate(buildDate string) {
+	cfg.Properties[buildDatePropName] = buildDate
+}
+
+func (cfg *Config) setBuilderName(name string) {
+	cfg.Properties[builderNamePropName] = name
+}
+
+func (cfg *Config) setBuilderEmail(email string) {
+	cfg.Properties[builderEmailPropName] = email
+}
+
+func (cfg *Config) setBuilderHost(host string) {
+	cfg.Properties[builderHostPropName] = host
+}
+
+// setImageHierarchy updates the config properties with a special BAKERY_IMAGE_HIERARCHY property.
+// Embedding this property in the chain of docker images allows for tracking entire hierarchy of the image including its
+// parents and versions
+func (cfg *Config) setImageHierarchy(dockerImage *DockerImage) {
+	parentVersionSuffix := ""
+	parentVersion := resolveVersion(dockerImage.DependsOnVersion, cfg)
+	parentImageName := dockerImage.DependsOnShort
+	if len(parentVersion) > 0 {
+		parentVersionSuffix = fmt.Sprintf(":%s", parentVersion)
+	}
+	commons.Debugf("Resolved parent version to: %s for: %s image", parentVersion, dockerImage.Name)
+
+	cfg.Properties[imageHierarchyPropName] = fmt.Sprintf("${BAKERY_IMAGE_HIERARCHY:-\"%s%s\"}->%s:%s",
+		parentImageName,
+		parentVersionSuffix,
+		dockerImage.Name,
+		dockerImage.GetNextVersionString())
+}
+
+// resolveVersion tries to resolve version string using dynamic properties from config
+// or falls back to provided version if it was not templated.
+func resolveVersion(versionToResolve string, cfg *Config) string {
+	if len(versionToResolve) == 0 {
+		return versionToResolve
+	}
+
+	t := template.New("version-substitution-template")
+	t, err := t.Parse(versionToResolve)
+	if err != nil {
+		commons.Debugf("Unable to parse version as a template, falling back to non templated version [%s], err: %s", versionToResolve, err)
+		return versionToResolve
+	}
+
+	buf := bytes.NewBufferString("")
+	t.Execute(buf, cfg.Properties)
+	return buf.String()
+}
+
+// buildSignature builds docker-bakery signature from several dynamic properties
+// and updates the config with new variables available for usage in templates.
+func (cfg *Config) buildSignature() {
+	signatureProperties := []string{builderNamePropName, builderEmailPropName, builderHostPropName, buildDatePropName, imageHierarchyPropName}
+	propsCount := len(signatureProperties)
+
+	var signatureValueBuf bytes.Buffer
+	var signatureEnvsBuf bytes.Buffer
+	for i, p := range signatureProperties {
+		signatureValueBuf.WriteString(cfg.Properties[p])
+		signatureEnvsBuf.WriteString(fmt.Sprintf("%s=\"%s\"", p, cfg.Properties[p]))
+		isNotLastProperty := i < propsCount-1
+		if isNotLastProperty {
+			signatureValueBuf.WriteString(";")
+			signatureEnvsBuf.WriteString(" \\\n")
+		}
+	}
+
+	cfg.Properties[signatureValuePropName] = signatureValueBuf.String()
+	cfg.Properties[signatureEnvsPropName] = signatureEnvsBuf.String()
 }
 
 // PrintProperties prints all properties available in the config (along with the dynamic ones).

--- a/bakery/service/dockerimage.go
+++ b/bakery/service/dockerimage.go
@@ -1,0 +1,45 @@
+package service
+
+import "github.com/Masterminds/semver"
+
+// GetLatestVersion returns latest version of the docker image or "0.0.0" if there was no version defined
+func (di *DockerImage) GetLatestVersion() *semver.Version {
+	if di.latestVersion != nil {
+		return di.latestVersion
+	}
+
+	di.latestVersion, _ = semver.NewVersion("0.0.0")
+	return di.latestVersion
+}
+
+// GetLatestVersionString returns the latest version (as a string) of the docker image or "0.0.0" if there was no version defined
+func (di *DockerImage) GetLatestVersionString() string {
+	return di.GetLatestVersion().String()
+}
+
+// CalculateNextVersion returns next version of the docker image based on the provided scope (major/minor/patch).
+// If image had no previous version the the 0.0.0 is used as a base line and appropriately updated with regards
+// to the provided scope.
+func (di *DockerImage) CalculateNextVersion(scope string) {
+	version := di.GetLatestVersion()
+	switch scope {
+	case "major":
+		di.nextVersion = version.IncMajor()
+	case "minor":
+		di.nextVersion = version.IncMinor()
+	case "patch":
+		di.nextVersion = version.IncPatch()
+	default:
+		di.nextVersion = version.IncPatch()
+	}
+}
+
+// GetNextVersion returns already calculated next version of the docker image.
+func (di *DockerImage) GetNextVersion() semver.Version {
+	return di.nextVersion
+}
+
+// GetNextVersionString returns already calculated next version (as a string) of the docker image.
+func (di *DockerImage) GetNextVersionString() string {
+	return di.nextVersion.String()
+}

--- a/bakery/service/entities.go
+++ b/bakery/service/entities.go
@@ -25,8 +25,11 @@ type DockerImage struct {
 	Name             string
 	DockerfileDir    string
 	DockerfilePath   string
-	DependsFromLong  string
-	DependsFromShort string
+	DependsOnLong    string
+	DependsOnShort   string
+	DependsOnVersion string
+	nextVersion      semver.Version
+	latestVersion    *semver.Version
 }
 
 // PostCommandListener is an interface that allows to plugin just after docker command is executed and before any commands on children are executed
@@ -61,7 +64,9 @@ type DockerHierarchy interface {
 	// Analyzes docker files structure under given directory and constructs entire hierarchy
 	AnalyzeStructure(string, map[string]*semver.Version) error
 	// Adds docker image to the hierarchy based on the docker image parent
-	AddImage(dockerImg *DockerImage, latestVersion *semver.Version)
+	AddImage(dockerImg *DockerImage)
+	// GetImageByName returns docker image by its name. Image can be obtained after entire hierarchy has been analyzed
+	GetImageByName(imageName string) *DockerImage
 	// Returns map with docker images where key is the short docker image name and
 	// the value is a slice of dependent images
 	GetImagesWithDependants() map[string][]*DockerImage

--- a/bakery/service/parser.go
+++ b/bakery/service/parser.go
@@ -55,21 +55,26 @@ func (dip *dockerImageParser) ParseDockerfile(dockerfilePath string) (*DockerIma
 			return nil, fmt.Errorf("unable to extract dependency from %s file. Check if first line starts with `FROM `", dockerfilePath)
 		}
 
-		dependsFromLong := strings.TrimPrefix(line, dependencyPrefix)
-		dependsFromShort := dependsFromLong
-		parts := strings.Split(dependsFromLong, "/")
+		dependsOnLong := strings.TrimPrefix(line, dependencyPrefix)
+		dependsOnShort := dependsOnLong
+		dependsOnVersion := ""
+		parts := strings.Split(dependsOnLong, "/")
 		if len(parts) <= 0 {
 			fmt.Printf("WARN: Unable to determine short base image name for: %s", dockerfilePath)
 		} else {
 			imgNameWithVersion := parts[len(parts)-1]
 			imgNameWithVersionParts := strings.Split(imgNameWithVersion, ":")
-			dependsFromShort = imgNameWithVersionParts[0]
+			dependsOnShort = imgNameWithVersionParts[0]
+			if len(imgNameWithVersionParts) > 1 {
+				dependsOnVersion = imgNameWithVersionParts[1]
+			}
 		}
 
 		return &DockerImage{
 			Name:             imageName,
-			DependsFromLong:  dependsFromLong,
-			DependsFromShort: dependsFromShort,
+			DependsOnLong:    dependsOnLong,
+			DependsOnShort:   dependsOnShort,
+			DependsOnVersion: dependsOnVersion,
 			DockerfileDir:    dockerfileDir,
 			DockerfilePath:   dockerfilePath}, nil
 	}


### PR DESCRIPTION
Introduced dynamic `BAKERY*` variables

- the most advanced variable is the BAKERY_IMAGE_HIERARCHY which has the potential of keeping entire image hierarchy along with parents and their versions
- refactored bakery file along with hierarchy and docker image
- renamed versions file to git which seems more adequate
- extracted some version related functionality to the docker image file
- updated documentation