### PR TITLE
Implemented dump-latest-versions command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME=docker-bakery
-VERSION=1.0.7
+VERSION=1.1.0
 
 .DEFAULT_GOAL: all
 

--- a/bakery/commands.go
+++ b/bakery/commands.go
@@ -110,5 +110,32 @@ func GetCommands() []cli.Command {
 			Usage:  "Used to display hierarchy of the images",
 			Action: commands.InitConfiguration,
 		},
+		{
+			Name:    "dump-latest-versions",
+			Aliases: []string{"dump"},
+			Hidden:  false,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "config, c",
+					Usage: "Required. Path to config.json with properties and build commands defined.",
+				},
+				cli.StringFlag{
+					Name:  "rootDir, rd",
+					Usage: "Optional. Used to override rootDir of the dockerfiles location. Can be defined in config.json, provided in this argument or determined dynamically from the base dir of config file.",
+				},
+				cli.StringFlag{
+					Name:  "file-name, file, f",
+					Usage: "Optional. File name where the result data will be stored in json format.",
+					Value: "docker-images.json",
+				},
+				cli.StringFlag{
+					Name:  "exclude-dirs, e",
+					Usage: "Optional. Pattern used to exclude images located in directories that match provided argument.",
+				},
+			},
+			Usage:  "Used to dump data about latest versions of images to the provided file",
+			Before: commands.InitConfiguration,
+			Action: commands.DumpLatestVersionsCmd,
+		},
 	}
 }

--- a/bakery/commands/bakery_actions.go
+++ b/bakery/commands/bakery_actions.go
@@ -28,3 +28,8 @@ func BuildDockerfileCmd(c *cli.Context) error {
 func PushDockerImagesCmd(c *cli.Context) error {
 	return service.PushDockerImages(c.String("d"), c.String("s"), !c.Bool("sd"))
 }
+
+// DumpLatestVersionsCmd dumps information about images and their latest versions to file in json format.
+func DumpLatestVersionsCmd(c *cli.Context) error {
+	return service.DumpLatestVersions(c.String("f"), c.String("e"))
+}

--- a/bakery/commons/fileutils.go
+++ b/bakery/commons/fileutils.go
@@ -69,7 +69,7 @@ func MakeDir(path string) error {
 	return err
 }
 
-// WriteToJSONFile marshals provided content to json and stores it in file with provided name.
+// WriteToJSONFile marshalls provided content to json and stores it in file with provided name.
 func WriteToJSONFile(content interface{}, fileName string) error {
 	data, err := json.MarshalIndent(content, prefix, indent)
 	if err != nil {

--- a/bakery/commons/fileutils.go
+++ b/bakery/commons/fileutils.go
@@ -1,9 +1,16 @@
 package commons
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path"
 	"text/template"
+)
+
+const (
+	prefix = ""
+	indent = "\t"
 )
 
 // FillTemplate fills source template from file and stores it under provided destination. To fill the template provided map with mappings is used.
@@ -60,4 +67,14 @@ func MakeDir(path string) error {
 		}
 	}
 	return err
+}
+
+// WriteToJSONFile marshals provided content to json and stores it in file with provided name.
+func WriteToJSONFile(content interface{}, fileName string) error {
+	data, err := json.MarshalIndent(content, prefix, indent)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(fileName, []byte(string(data[:])+"\n"), 0755)
 }

--- a/bakery/service/bakery.go
+++ b/bakery/service/bakery.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -73,6 +74,44 @@ func InitConfiguration(configFile, rootDir string) error {
 	dependencies = hierarchy.GetImagesWithDependants()
 
 	return nil
+}
+
+// DumpLatestVersions saves images with their latest version in json format to file.
+// Optionally it can exclude images from provided directories.
+func DumpLatestVersions(fileName, excludeDirsPattern string) error {
+	filterOutImagesFromDirs(excludeDirsPattern)
+	filterOutNotExistingImages()
+	return commons.WriteToJSONFile(versions, fileName)
+}
+
+// filterOutImagesFromDirs removes images that are stored in directories that match provided pattern.
+func filterOutImagesFromDirs(excludeDirsPattern string) {
+	if len(excludeDirsPattern) > 0 {
+		r, _ := regexp.Compile(excludeDirsPattern)
+		images := hierarchy.GetImages()
+		for imgName, img := range images {
+			shouldExcludeImage := r.MatchString(img.DockerfileDir)
+			if shouldExcludeImage {
+				delete(versions, imgName)
+				if config.Verbose {
+					fmt.Printf("Excluding image from %s as it matches pattern %s\n", img.DockerfileDir, excludeDirsPattern)
+				}
+			}
+		}
+	}
+}
+
+// filterOutNotExistingImages removes images that no longer exist but still may be present in git tags.
+func filterOutNotExistingImages() {
+	images := hierarchy.GetImages()
+	for imgName := range versions {
+		if _, exists := images[imgName]; !exists {
+			delete(versions, imgName)
+			if config.Verbose {
+				fmt.Printf("Excluding non existing image %s\n", imgName)
+			}
+		}
+	}
 }
 
 func updateConfigProperties() {
@@ -266,6 +305,10 @@ func ExecuteDockerCommand(command, dockerfile, scope string, postCmdListener Pos
 // Executes command and prints to the stdout its output.
 func executeCommand(command string) error {
 	t, err := template.New("dockerCmd").Parse(command)
+	if err != nil {
+		return err
+	}
+
 	var cmdBuf bytes.Buffer
 	err = t.Execute(&cmdBuf, config.Properties)
 	if err != nil {

--- a/bakery/service/bakery.go
+++ b/bakery/service/bakery.go
@@ -86,17 +86,17 @@ func DumpLatestVersions(fileName, excludeDirsPattern string) error {
 
 // filterOutImagesFromDirs removes images that are stored in directories that match provided pattern.
 func filterOutImagesFromDirs(excludeDirsPattern string) {
-	if len(excludeDirsPattern) > 0 {
-		r, _ := regexp.Compile(excludeDirsPattern)
-		images := hierarchy.GetImages()
-		for imgName, img := range images {
-			shouldExcludeImage := r.MatchString(img.DockerfileDir)
-			if shouldExcludeImage {
-				delete(versions, imgName)
-				if config.Verbose {
-					fmt.Printf("Excluding image from %s as it matches pattern %s\n", img.DockerfileDir, excludeDirsPattern)
-				}
-			}
+	if len(excludeDirsPattern) <= 0 {
+		return
+	}
+
+	r, _ := regexp.Compile(excludeDirsPattern)
+	images := hierarchy.GetImages()
+	for imgName, img := range images {
+		shouldExcludeImage := r.MatchString(img.DockerfileDir)
+		if shouldExcludeImage {
+			delete(versions, imgName)
+			commons.Debugf("Excluding image from %s as it matches pattern %s", img.DockerfileDir, excludeDirsPattern)
 		}
 	}
 }
@@ -107,9 +107,7 @@ func filterOutNotExistingImages() {
 	for imgName := range versions {
 		if _, exists := images[imgName]; !exists {
 			delete(versions, imgName)
-			if config.Verbose {
-				fmt.Printf("Excluding non existing image %s\n", imgName)
-			}
+			commons.Debugf("Excluding non existing image %s", imgName)
 		}
 	}
 }

--- a/bakery/service/entities.go
+++ b/bakery/service/entities.go
@@ -70,6 +70,9 @@ type DockerHierarchy interface {
 	// Returns map with docker images where key is the short docker image name and
 	// the value is a slice of dependent images
 	GetImagesWithDependants() map[string][]*DockerImage
+	// Returns map with docker images where key is the short docker image name and
+	// the value is docker image object
+	GetImages() map[string]*DockerImage
 	// Prints gathered hierarchy under a given root name
 	PrintImageHierarchy(string)
 }

--- a/bakery/service/hierarchy.go
+++ b/bakery/service/hierarchy.go
@@ -90,6 +90,11 @@ func (h *dockerHierarchy) GetImagesWithDependants() map[string][]*DockerImage {
 	return h.imagesWithDependantsMap
 }
 
+// Return the map of docker images where key is the image name and value is the docker image object.
+func (h *dockerHierarchy) GetImages() map[string]*DockerImage {
+	return h.images
+}
+
 // Creates the first level of the hierarchy tree. External images are qualified as first level parents.
 func (h *dockerHierarchy) createFirstLevelRoots() {
 	for _, i := range h.imagesTreeSlice {


### PR DESCRIPTION
Implemented dump-latest-versions command
- the result `json` file is stored with contents where key is image name and value is the latest image version
- optionally results can be filtered based on provided directory filter
- Images that no longer exists (but may still be present in git tags are excluded by default)