### PR TITLE
Implemented possibility to override custom properties during runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME=docker-bakery
-VERSION=1.1.0
+VERSION=1.2.0
 
 .DEFAULT_GOAL: all
 

--- a/bakery/commands.go
+++ b/bakery/commands.go
@@ -30,6 +30,10 @@ func GetCommands() []cli.Command {
 					Name:  "rootDir, rd",
 					Usage: "Optional. Used to override rootDir of the dockerfiles location. Can be defined in config.json, provided in this argument or determined dynamically from the base dir of config file.",
 				},
+				cli.StringSliceFlag{
+					Name:  "property, p",
+					Usage: "Optional. Allows for providing additional multiple properties that can be used during templating. Overrides properties defined in config.json file. Expected format is: -p propertyName=propertyValue",
+				},
 			},
 			Usage:  "Used to fill Dockerfile.template file. Values needed for template are taken from the config file and from dynamic properties provided during runtime.",
 			Before: commands.InitConfiguration,
@@ -58,6 +62,10 @@ func GetCommands() []cli.Command {
 				cli.BoolFlag{
 					Name:  "skip-dependants, sd",
 					Usage: "Optional. False be default. If this flag is set build of the parent will not trigger dependant builds.",
+				},
+				cli.StringSliceFlag{
+					Name:  "property, p",
+					Usage: "Optional. Allows for providing additional multiple properties that can be used during templating. Overrides properties defined in config.json file. Expected format is: -p propertyName=propertyValue",
 				},
 			},
 			Usage:  "Used to build next version of the images in given scope. Optionally it can skip build of dependant images.",

--- a/bakery/commands/bakery_actions.go
+++ b/bakery/commands/bakery_actions.go
@@ -9,7 +9,7 @@ import (
 // InitConfiguration initializes configuration for the rest of invoked commands.
 // Receives config file path and optionally root directory to override the config section.
 func InitConfiguration(c *cli.Context) error {
-	return service.InitConfiguration(c.String("c"), c.String("rd"))
+	return service.InitConfiguration(c.String("c"), c.String("rd"), c.StringSlice("p"))
 }
 
 // FillTemplateCmd fills input dockerfile template and stores the result under provided output.


### PR DESCRIPTION
Implemented possibility to override custom properties during runtime

It is for example possible to invoke the build with additional properties in such way:
`docker-bakery build ... --property foo1=bar1 --property foo2=bar2` this gives us a way do deliver custom properties that should be dynamically evaluated and cannot be stored in config file.