### PR TITLE
Default parent version when unknown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME=docker-bakery
-VERSION=1.3.1
+VERSION=1.3.2
 
 .DEFAULT_GOAL: all
 

--- a/bakery/service/bakery.go
+++ b/bakery/service/bakery.go
@@ -83,7 +83,7 @@ func InitConfiguration(configFile, rootDir string, additionalProperties []string
 // we're still able to produce valid Dockerfile with parent image version set to 0.0.0
 func updateUnknownParentsVersions(h DockerHierarchy) {
 	nonExisting := make([]string, 0)
-	for imageName, _ := range h.GetImages() {
+	for imageName := range h.GetImages() {
 		dynamicName := dynamicImageVersionName(imageName)
 		if _, ok := config.Properties[dynamicName]; !ok {
 			nonExisting = append(nonExisting, imageName)

--- a/bakery/service/bakery.go
+++ b/bakery/service/bakery.go
@@ -89,8 +89,8 @@ func updateUnknownParentsVersions(h DockerHierarchy) {
 			nonExisting = append(nonExisting, imageName)
 		}
 	}
-	for _, dynamicVersionName := range nonExisting {
-		config.setDynamicImageVersionProperty(dynamicVersionName, "0.0.0")
+	for _, imageName := range nonExisting {
+		config.setDynamicImageVersionProperty(imageName, "0.0.0")
 	}
 }
 

--- a/bakery/service/bakery.go
+++ b/bakery/service/bakery.go
@@ -70,11 +70,28 @@ func InitConfiguration(configFile, rootDir string, additionalProperties []string
 		return err
 	}
 
+	updateUnknownParentsVersions(hierarchy)
+
 	rootName := fmt.Sprintf("Dockerfiles hierarchy discovered in %s", config.RootDir)
 	hierarchy.PrintImageHierarchy(rootName)
 	dependencies = hierarchy.GetImagesWithDependants()
 
 	return nil
+}
+
+// updateUnknownParentsVersions makes sure that when building an image whose parent x_VERSION from template is unknown,
+// we're still able to produce valid Dockerfile with parent image version set to 0.0.0
+func updateUnknownParentsVersions(h DockerHierarchy) {
+	nonExisting := make([]string, 0)
+	for imageName, _ := range h.GetImages() {
+		dynamicName := dynamicImageVersionName(imageName)
+		if _, ok := config.Properties[dynamicName]; !ok {
+			nonExisting = append(nonExisting, imageName)
+		}
+	}
+	for _, dynamicVersionName := range nonExisting {
+		config.setDynamicImageVersionProperty(dynamicVersionName, "0.0.0")
+	}
 }
 
 // DumpLatestVersions saves images with their latest version in json format to file.

--- a/bakery/service/config.go
+++ b/bakery/service/config.go
@@ -73,12 +73,16 @@ func (cfg *Config) UpdateVersionProperties(versions map[string]*semver.Version) 
 // The result of invocation setDynamicImageVersionProperty('redis', '1.0.0')
 // would be property REDIS_VERSION = '1.0.0'
 func (cfg *Config) setDynamicImageVersionProperty(imgName, version string) {
+	propertyName := dynamicImageVersionName(imgName)
+	commons.Debugf("Setting property %s to %s", propertyName, version)
+	cfg.Properties[propertyName] = version
+}
+
+func dynamicImageVersionName(imgName string) string {
 	imgNameInTmpl := strings.ToUpper(imgName)
 	imgNameInTmpl = strings.Replace(imgNameInTmpl, "-", "_", -1)
 	imgNameInTmpl = strings.Replace(imgNameInTmpl, ".", "_", -1)
-	propertyName := fmt.Sprintf("%s_VERSION", imgNameInTmpl)
-	commons.Debugf("Setting property %s to %s", propertyName, version)
-	cfg.Properties[propertyName] = version
+	return fmt.Sprintf("%s_VERSION", imgNameInTmpl)
 }
 
 // setImageVersion sets the IMAGE_VERSION property to the provided version.


### PR DESCRIPTION
Right now, when introducing new dockerfiles tree, when trying to build child image from template, the resulting Dockerfile `FROM` clause has incorrect target image version set to `image-name:<no value>` which breaks during linting for example.

When there is no valid version of the parent image, the resulted Dockerfile will have a version `0.0.0` specified.
