### PR TITLE
Trim "AS name" from the FROM clause

### DIFF
--- a/bakery/service/parser.go
+++ b/bakery/service/parser.go
@@ -55,6 +55,11 @@ func (dip *dockerImageParser) ParseDockerfile(dockerfilePath string) (*DockerIma
 			return nil, fmt.Errorf("unable to extract dependency from %s file. Check if first line starts with `FROM `", dockerfilePath)
 		}
 
+		asNameIndex := strings.Index(line, " AS ")
+		if asNameIndex != -1 {
+			line = line[:asNameIndex]
+		}
+
 		dependsOnLong := strings.TrimPrefix(line, dependencyPrefix)
 		dependsOnShort := dependsOnLong
 		dependsOnVersion := ""

--- a/bakery/service/parser.go
+++ b/bakery/service/parser.go
@@ -55,10 +55,8 @@ func (dip *dockerImageParser) ParseDockerfile(dockerfilePath string) (*DockerIma
 			return nil, fmt.Errorf("unable to extract dependency from %s file. Check if first line starts with `FROM `", dockerfilePath)
 		}
 
-		asNameIndex := strings.Index(line, " AS ")
-		if asNameIndex != -1 {
-			line = line[:asNameIndex]
-		}
+		// keep only "FROM <image-name>" part of the line, so "AS <stage-name>" is removed
+		line = strings.Join(strings.Fields(line)[0:2], " ")
 
 		dependsOnLong := strings.TrimPrefix(line, dependencyPrefix)
 		dependsOnShort := dependsOnLong

--- a/bakery/service/parser_test.go
+++ b/bakery/service/parser_test.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func copyDockerImgObjectForCompare(dockerImg *DockerImage) *DockerImage {
+	return &DockerImage{
+		Name:             dockerImg.Name,
+		DockerfilePath:   "dummy",
+		DockerfileDir:    dockerImg.DockerfileDir,
+		DependsOnLong:    dockerImg.DependsOnLong,
+		DependsOnShort:   dockerImg.DependsOnShort,
+		DependsOnVersion: dockerImg.DependsOnVersion,
+		nextVersion:      dockerImg.nextVersion,
+		latestVersion:    dockerImg.latestVersion,
+	}
+}
+
+func TestParserDependenciesFromFromClause(t *testing.T) {
+	dockerImgParser := NewDockerImageParser()
+
+	dockerImgUnnamed, _ := dockerImgParser.ParseDockerfile("testcases/Dockerfile1")
+	dockerImgUnnamedCopy := copyDockerImgObjectForCompare(dockerImgUnnamed)
+
+	dockerImgNamedUppercase, _ := dockerImgParser.ParseDockerfile("testcases/Dockerfile2")
+	dockerImgNamedUppercaseCopy := copyDockerImgObjectForCompare(dockerImgNamedUppercase)
+
+	dockerImgNamedLowercase, _ := dockerImgParser.ParseDockerfile("testcases/Dockerfile3")
+	dockerImgNamedLowercaseCopy := copyDockerImgObjectForCompare(dockerImgNamedLowercase)
+
+	assert.Equal(t, dockerImgUnnamed.DependsOnLong, "ubuntu:2204")
+	assert.Equal(t, dockerImgUnnamed.DependsOnShort, "ubuntu")
+	assert.Equal(t, dockerImgUnnamed.DependsOnVersion, "2204")
+
+	assert.Equal(t, dockerImgUnnamedCopy, dockerImgNamedUppercaseCopy)
+	assert.Equal(t, dockerImgUnnamedCopy, dockerImgNamedLowercaseCopy)
+	assert.Equal(t, dockerImgNamedUppercaseCopy, dockerImgNamedLowercaseCopy)
+}

--- a/bakery/service/testcases/Dockerfile1
+++ b/bakery/service/testcases/Dockerfile1
@@ -1,0 +1,1 @@
+FROM ubuntu:2204

--- a/bakery/service/testcases/Dockerfile2
+++ b/bakery/service/testcases/Dockerfile2
@@ -1,0 +1,1 @@
+FROM ubuntu:2204 AS base

--- a/bakery/service/testcases/Dockerfile3
+++ b/bakery/service/testcases/Dockerfile3
@@ -1,0 +1,1 @@
+FROM ubuntu:2204 as base


### PR DESCRIPTION
Motivation: as I'm very interested in multistage builds, especially named stages, what about cutting the entire `AS name` from the `FROM` clause? This will allow us to use Dockerfiles like this:

```
FROM ubuntu:22.04 AS base
[..] do something common [...]

FROM base AS stage-amd64
[..] do something for AMD [..]

FROM base AS stage-arm64
[..] do something for ARM [..]

FROM stage-$TARGETARCH
[..] do another common [..]
```

Changes:
1. Trim `AS name` from the FROM clause
2. Added tests for parsing Dockerfile and compare named and unnamed FROM clauses